### PR TITLE
Improve testing workflow to select correct environment and handle pandas / python version for map function

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -42,7 +42,7 @@ jobs:
           done
 
       - name: Run notebook tests
-        run: pytest --nbval-lax --current-env tests/
+        run: pytest --nbval-lax --nbval-current-env tests/
 
       - name: Upload executed notebooks on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,8 @@ __pycache__
 *.Identifier
 !requirements.txt
 .jupyter_cache
+
+# Ignore log files
+tests/*.log
 tests/multiprocess_log.txt
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,6 @@ __pycache__
 .jupyter_cache
 
 # Ignore log files
-tests/*.log
+tests/**/*.log
 tests/multiprocess_log.txt
 .vscode

--- a/pyAMARES/kernel/PriorKnowledge.py
+++ b/pyAMARES/kernel/PriorKnowledge.py
@@ -181,6 +181,9 @@ def unitconverter(df_ini, MHz=120.0):
         pandas.DataFrame: A DataFrame with converted unit values in specified rows.
     """
     df = deepcopy(df_ini)
+    df = df.apply(
+        pd.to_numeric, errors="raise", downcast="float"
+    )  # By this point the values should only be numeric
     if "chemicalshift" in df.index:
         df.loc["chemicalshift", df.notna().loc["chemicalshift"]] *= MHz
 
@@ -189,7 +192,7 @@ def unitconverter(df_ini, MHz=120.0):
 
     if "phase" in df.index:
         df.loc["phase", df.notna().loc["phase"]] = np.deg2rad(
-            df.loc["phase"][df.notna().loc["phase"]].astype(float)
+            df.loc["phase"][df.notna().loc["phase"]]
         )
 
     return df

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --nbval-lax
+addopts = --nbval-lax --nbval-current-env
 testpaths = tests


### PR DESCRIPTION
Hi Jia,

this pull request introduces improvements to both the testing workflow and the codebase to enhance compatibility across development environments. 

**Testing workflow updates:**

* Updated the notebook test command in `.github/workflows/test-notebooks.yml` and `pytest.ini` to use the `--nbval-current-env` flag, ensuring that notebook tests run in the current Python environment rather than a potentially isolated one.

**Pandas / Python version compatibility:**

* Refactored numeric conversion logic by introducing a `backward_compatible_map` function to handle differences between pandas versions (`map` for >=2.1.0, `applymap` for older versions). This is similar to your [commit last week](https://github.com/HawkMRS/pyAMARES/commit/0cbd22e68c5a950088420deb8f7904275f4ac6db), but should improve maintainability.

**Minor bug fix:**

* Simplified the conversion of phase values to radians in `unitconverter` by removing unnecessary type casting, relying on prior numeric conversion.