### PR TITLE
fix: use PEP 508 environment markers for hlsvdpro (Resolves #15)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import ast
 import glob
 import os
-import platform
 
 from setuptools import find_packages, setup
 from setuptools.command.sdist import sdist as _sdist
@@ -95,13 +94,12 @@ install_requires = [
     "requests",
     "ipywidgets>=7.6.0,<8.0.0;python_version<'3.11'",  # For older Python versions
     "ipywidgets>=8.0.0;python_version>='3.11'",  # For newer Python versions
+    # Use the better-performing 'hlsvdpro' package if running on supported platforms
+    # (e.g., x86_64 or amd64 architectures). Otherwise, fall back to the custom
+    # 'hlsvdpropy' implementation located in pyAMARES/libs/hlsvd.py.
+    # (Refactored to PEP 508 markers in Issue #15 for Apple Silicon/uv compatibility)
+    "hlsvdpro>=2.0.0; platform_machine == 'x86_64' or platform_machine == 'amd64'",
 ]
-
-# Use the better-performing 'hlsvdpro' package if running on supported platforms
-# (e.g., x86_64 or amd64 architectures). Otherwise, fall back to the custom
-# 'hlsvdpropy' implementation located in pyAMARES/libs/hlsvd.py.
-if platform.machine().lower() in ["x86_64", "amd64"]:
-    install_requires.append("hlsvdpro>=2.0.0")
 
 
 setup(


### PR DESCRIPTION
Resolves #15 

**What does this PR do?**
This PR moves the platform-specific requirement for `hlsvdpro` from a build-time Python `if` statement into an install-time PEP 508 environment marker within the `install_requires` list. 

**Why is this necessary?**
Previously, because the PyPI wheels were built on x86_64 machines, `hlsvdpro` was permanently baked into the static wheel metadata as a requirement for all platforms. This caused strict, metadata-first package managers like `uv` (and modern `pip`) to crash on Apple Silicon (ARM64) Macs when they couldn't find a matching wheel.

By using environment markers, the platform evaluation now correctly happens on the user's machine at install-time, bypassing `hlsvdpro` natively on ARM64 architectures while preserving it for Intel/AMD users.

**Changes:**
- Removed the `if platform.machine().lower() in ["x86_64", "amd64"]:` block in `setup.py`.
- Appended `"hlsvdpro>=2.0.0; platform_machine == 'x86_64' or platform_machine == 'amd64'"` directly to `install_requires`.