### PR TITLE
fix: pin pandas and numpy to prevent strict typing crashes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,10 +79,10 @@ ruff_requirements = [
 
 
 install_requires = [
-    "pandas>=1.1.0",
+    "pandas>=1.1.0,<2.2.0",
     "matplotlib>=3.1.3",
     "lmfit",
-    "numpy>=1.18.1",
+    "numpy>=1.18.1,<2.0.0",
     "scipy>=1.2.1",
     "sympy",
     "nmrglue",


### PR DESCRIPTION
Resolves #17 

**What does this PR do?**
Restricts the allowed versions of `pandas` (`< 2.2.0`) and `numpy` (`< 2.0.0`) in the package dependencies.

**Why is this necessary?**
Recent releases of Pandas and NumPy introduced strict type-enforcement and removed implicit upcasting. This causes the current `pyAMARES` codebase to crash with `LossySetitemError` (during unit conversions) and `AttributeError` (when manipulating empty DataFrames resulting from peak filtering).

By pinning these dependencies to their last known stable versions, we immediately restore usability for end-users (at least python 3.11 and 3.12 it seems) while we can work on a comprehensive codebase update in a separate PR.