### PR TITLE
Draft: Modernize codebase for Pandas 2.2+ and NumPy 2.0+ compatibility

### DIFF
--- a/pyAMARES/kernel/PriorKnowledge.py
+++ b/pyAMARES/kernel/PriorKnowledge.py
@@ -369,6 +369,11 @@ def generateparameter(
             lval = df_lb2[peak].iloc[i]
             uval = df_ub2[peak].iloc[i]
             expr = df_expr[peak].iloc[i]
+
+            # --- FIX: Ensure expr is None if it evaluates to NaN ---
+            if pd.isna(expr):
+                expr = None
+
             # Handle NaN values for bounds
             if np.isnan(lval):
                 lval = -np.inf


### PR DESCRIPTION
Resolves #17  (Long-term solution)

**What does this PR do?**
This Draft PR begins the process of refactoring the codebase to comply with the strict type-enforcement and Copy-on-Write behaviors introduced in recent versions of Pandas (>= 2.2.0) and NumPy (>= 2.0.0), as well as modern `lmfit`/`asteval` versions. 

This is the long-term solution to the temporary dependency pins implemented in #18 .


Feel free to push commits directly to this branch or let me know if anyone wants to take the lead on finishing this!